### PR TITLE
Update Spring Boot and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.14</version>
+		<version>3.2.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.starkandwayne</groupId>
@@ -14,9 +14,9 @@
 	<name>service-registry</name>
 	<description>Service Registry for Stark And Wayne</description>
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 		<spring-cloud-services.version>3.4.0</spring-cloud-services.version>
-		<spring-cloud.version>2020.0.4</spring-cloud.version>
+		<spring-cloud.version>2023.0.1</spring-cloud.version>
 	</properties>
 	<dependencies>
 
@@ -45,7 +45,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>2020.0.4</version>
+				<version>${spring-cloud.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
- Upgraded Spring Boot version from 2.5.14 to 3.2.4
- Updated Java version from 1.8 to 17
- Updated Spring Cloud Services version to 2023.0.1
- Changed spring-cloud-dependencies version reference to use property