### PR TITLE
upgrade: Spring Boot to 3.3.7 & Spring Cloud 2023.0.4, fix test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,19 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<version>3.3.7</version>
+		<relativePath/>
 	</parent>
 	<groupId>com.starkandwayne</groupId>
 	<artifactId>service-registry</artifactId>
-	<version>2.0.0-3.4.0</version>
+	<version>2.0.1-3.4.0</version>
 	<name>service-registry</name>
 	<description>Service Registry for Stark And Wayne</description>
 	<properties>
 		<java.version>17</java.version>
 		<spring-cloud-services.version>3.4.0</spring-cloud-services.version>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
+		<!-- Upgrade Spring Cloud BOM to latest 2023.0.x patch for security/bug fixes -->
+		<spring-cloud.version>2023.0.4</spring-cloud.version>
 	</properties>
 	<dependencies>
 

--- a/src/test/java/com/starkandwayne/serviceregistry/ServiceRegistryApplicationTests.java
+++ b/src/test/java/com/starkandwayne/serviceregistry/ServiceRegistryApplicationTests.java
@@ -3,11 +3,10 @@ package com.starkandwayne.serviceregistry;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-
+@SpringBootTest
 class ServiceRegistryApplicationTests {
-
-
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {
+        // Context loads test
+    }
 }


### PR DESCRIPTION
This pull request updates dependency versions for Spring Boot and Spring Cloud in the `pom.xml` to address security and bug fixes, and makes a minor improvement to the test class by adding the `@SpringBootTest` annotation.

Dependency upgrades:

* Upgraded Spring Boot parent version from `3.2.4` to `3.3.7` in `pom.xml` for improved stability and security.
* Upgraded Spring Cloud BOM version from `2023.0.1` to `2023.0.4` in `pom.xml` to incorporate the latest security and bug fixes.
* Updated project version from `2.0.0-3.4.0` to `2.0.1-3.4.0` in `pom.xml`.

Testing improvements:

* Added `@SpringBootTest` annotation to `ServiceRegistryApplicationTests.java` to ensure the Spring context loads during tests